### PR TITLE
DEV-622 [FIX] Show error and hide save button when widget is outside LFD.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -3,29 +3,31 @@ let htmlToShow = '';
 let dataSourceObj = null;
 
 Fliplet.Widget.findParents({ filter: { package: 'com.fliplet.dynamic-container' } }).then(async widgets => {
-  if (widgets.length === 0) {
-    htmlToShow = '<p style="font-size: 10px; font-weight: 400; color: #E7961E;">To change Data source go to Data Container Settings on the LFD page</p>';
-  } else {
-    dynamicContainer = widgets[0];
+  dynamicContainer = widgets[0];
 
-    if (dynamicContainer) {
-      if (dynamicContainer.dataSourceId) {
-        dataSourceObj = await Fliplet.DataSources.getById(dynamicContainer.dataSourceId, {
-          attributes: ['name']
-        }).then(dataSource => {
-          return dataSource;
-        });
+  if (widgets.length === 0 || !dynamicContainer.dataSourceId) {
+    Fliplet.Widget.generateInterface({
+      title: 'Configure data filter',
+      fields: [
+        {
+          type: 'html',
+          html: '<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">This component needs to be placed inside a Data container with selected Data source</p>'
+        }
+      ]
+    });
 
-        htmlToShow = `<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">List from ${dataSourceObj.name}(ID: <span class="data-source-id">${dynamicContainer.dataSourceId}</span>)</p>
+    return Fliplet.UI.Toast('This component needs to be placed inside a Data container with selected Data source');
+  }
+
+  dataSourceObj = await Fliplet.DataSources.getById(dynamicContainer.dataSourceId, {
+    attributes: ['name']
+  }).then(dataSource => {
+    return dataSource;
+  });
+
+  htmlToShow = `<p style="color: #A5A5A5; font-size: 12px; font-weight: 400;">List from ${dataSourceObj.name}(ID: <span class="data-source-id">${dynamicContainer.dataSourceId}</span>)</p>
         <p style="font-size: 10px; font-weight: 400; color: #E7961E;">To change Data source go to Data Container Settings</p>
         <hr/>`;
-      } else {
-        htmlToShow = '<p style="font-size: 10px; font-weight: 400; color: #E7961E;">Please select Data source from Data Container Settings</p>';
-      }
-    } else {
-      htmlToShow = '<p style="font-size: 10px; font-weight: 400; color: #E7961E;">Data Container component is required</p>';
-    }
-  }
 
   return Fliplet.Widget.generateInterface({
     title: 'Filter container',


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Filter Container

### What does this PR do?

Show error and hide save button when widget is outside LFD.

### JIRA ticket

[DEV-622](https://weboo.atlassian.net/browse/DEV-622)

[DEV-622]: https://weboo.atlassian.net/browse/DEV-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified behaviour when a widget or data source is missing: shows a Configure data filter interface with a toast, replacing confusing messages and avoiding dead ends.

* **Refactor**
  * Streamlined the data-loading flow for dynamic containers with early exits on missing prerequisites.
  * Centralised the successful path to load and display the selected data source, with updated on-screen guidance for configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->